### PR TITLE
Windows Library Functions

### DIFF
--- a/PythonPlugin/OpenEphysLib.cpp
+++ b/PythonPlugin/OpenEphysLib.cpp
@@ -25,7 +25,9 @@
  
  */
 
-// contents of OpenEphysLib.cpp
+#include "PythonFilter.h"
+#include "PythonSource.h"
+#include "PythonSink.h"
 
 #include <PluginInfo.h>
 #include <string>
@@ -35,10 +37,6 @@
 #else
 #define EXPORT
 #endif
-
-#include "PythonFilter.h"
-#include "PythonSource.h"
-#include "PythonSink.h"
 
 using namespace Plugin;
 //Number of plugins defined on the library. Can be of different types (Processors, RecordEngines, etc...)
@@ -96,6 +94,4 @@ BOOL WINAPI DllMain(IN HINSTANCE hDllHandle,
     return TRUE;
 }
 
-
-
-#endif // __IGNORE_PYTHON_PLUGIN
+#endif

--- a/PythonPlugin/PythonEditor.cpp
+++ b/PythonPlugin/PythonEditor.cpp
@@ -34,9 +34,8 @@
   ==============================================================================
 */
 
-#include "PythonEditor.h"
-
 #include "PythonPlugin.h"
+#include "PythonEditor.h"
 
 #include <stdio.h>
 
@@ -67,7 +66,7 @@ PythonEditor::PythonEditor(GenericProcessor* parentNode, bool useDefaultParamete
 
 PythonEditor::~PythonEditor()
 {
-    for(int i= 0; i < parameterInterfaces.size(); i++)
+    for(int i=0; i < parameterInterfaces.size(); i++)
     {
         removeChildComponent(parameterInterfaces[i]);
     }
@@ -325,7 +324,7 @@ void PythonParameterComboBoxInterface::comboBoxChanged(ComboBox* comboBox)
 
 void PythonParameterComboBoxInterface::setEntryFromValue(int value)
 {
-    int id = 0;
+    int id;
     for (int i = 0; i < nEntries; i++)
     {
         if(entries[i]==value)

--- a/PythonPlugin/PythonPlugin.cpp
+++ b/PythonPlugin/PythonPlugin.cpp
@@ -685,18 +685,16 @@ void PythonPlugin::setFile(String fullpath)
 #endif
     if (!plugin)
       {
+		  std::cout << "Can't open plugin "
+			  << '"' << path << "\""	  
 #ifdef _WIN32
-		  std::cout << "Can't open plugin "
-			  << '"' << path << "\"" 
-			  << std::endl << GetLastErrorAsString() << std::endl;
-		  return;
+              << GetLastErrorAsString()
 #else
-		  std::cout << "Can't open plugin "
-			  << '"' << path << "\""
-			  << dlerror()
-			  << std::endl;
-		  return;
+              << dlerror()	  
 #endif
+              << std::endl;
+		  return;
+
       }
 
     //String initPlugin = filePath.fromLastOccurrenceOf(String("/"), false, true);
@@ -727,19 +725,16 @@ void PythonPlugin::setFile(String fullpath)
 #endif
     if (!initializer)
     {
-#ifdef _WIN32
-        std::cout << "Can't find init function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-        plugin = 0;
-        return;
-#else
         std::cout << "Can't find init function in plugin "
             << '"' << path << "\"" << std::endl
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
             << dlerror()
+#endif
             << std::endl;
         plugin = 0;
         return;
-#endif
     }
 
     initfunc_t initF = (initfunc_t) initializer;
@@ -751,19 +746,16 @@ void PythonPlugin::setFile(String fullpath)
 #endif
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find ready function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find ready function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     pluginIsReady = (isreadyfunc_t)cfunc;
 
@@ -774,19 +766,16 @@ void PythonPlugin::setFile(String fullpath)
 #endif
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find startup function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find startup function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()	  
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     pluginStartupFunction = (startupfunc_t)cfunc;
     
@@ -798,19 +787,16 @@ void PythonPlugin::setFile(String fullpath)
 
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find getParamNum function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find getParamNum function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()	  
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     getParamNumFunction = (getparamnumfunc_t)cfunc;
     
@@ -822,19 +808,17 @@ void PythonPlugin::setFile(String fullpath)
 #endif
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find getParamNum function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		   	plugin = 0; 
-		   	return;
-#else
 		std::cout << "Can't find getParamNum function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
-			<< std::endl;
-		//   	plugin = 0;
-		//   	return;
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
 #endif
+			<< std::endl;
+		   	plugin = 0;
+		   	return;
+
     }
     getParamConfigFunction = (getparamconfigfunc_t)cfunc;
 
@@ -847,19 +831,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find plugin function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find plugin function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()	  
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     pluginFunction = (pluginfunc_t)cfunc;
     
@@ -872,19 +853,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find plugin function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find plugin function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
 
     }
     eventFunction = (eventfunc_t)cfunc;
@@ -897,19 +875,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find plugin function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find plugin function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     spikeFunction = (spikefunc_t)cfunc;
     
@@ -923,19 +898,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find setIntParam function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
     	std::cout << "Can't find setIntParam function in plugin "
         << '"' << path << "\"" << std::endl
+#ifdef _WIN32
+        << GetLastErrorAsString()
+#else
         << dlerror()
+#endif
         << std::endl;
     	plugin = 0;
     	return;
-#endif
     }
     setIntParamFunction = (setintparamfunc_t)cfunc;
     
@@ -947,19 +919,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find setFloatParam function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find setFloatParam function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
 
     setFloatParamFunction = (setfloatparamfunc_t)cfunc;
@@ -973,19 +942,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find getIntParam function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
         std::cout << "Can't find getIntParam function in plugin "
         << '"' << path << "\"" << std::endl
+#ifdef _WIN32
+        << GetLastErrorAsString()
+#else
         << dlerror()
+#endif
         << std::endl;
         plugin = 0;
         return;
-#endif
     }
     getIntParamFunction = (getintparamfunc_t)cfunc;
     
@@ -997,19 +963,16 @@ void PythonPlugin::setFile(String fullpath)
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-#ifdef _WIN32
-		std::cout << "Can't find getFloatParam function in plugin "
-            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
-		plugin = 0;
-		return;
-#else
 		std::cout << "Can't find getFloatParam function in plugin "
 			<< '"' << path << "\"" << std::endl
-			<< dlerror()
+#ifdef _WIN32
+            << GetLastErrorAsString()
+#else
+            << dlerror()
+#endif
 			<< std::endl;
 		plugin = 0;
 		return;
-#endif
     }
     
     getFloatParamFunction = (getfloatparamfunc_t)cfunc;

--- a/PythonPlugin/PythonPlugin.cpp
+++ b/PythonPlugin/PythonPlugin.cpp
@@ -37,24 +37,27 @@ v
 #include "PythonPlugin.h"
 #include "PythonEditor.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef DEBUG
-//#define PYTHON_DEBUG TRUE
+#define PYTHON_DEBUG TRUE
 #endif
 
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
 #include <sys/syscall.h>
 #include <unistd.h>
-#else
+#elif !defined(_WIN32)
 #include <pthread.h> 
 #endif
 #endif
-
-
 
 
 PythonPlugin::PythonPlugin(const String &processorName)
@@ -65,21 +68,28 @@ PythonPlugin::PythonPlugin(const String &processorName)
     //parameters.add(Parameter("thresh", 0.0, 500.0, 200.0, 0));
     filePath = "";
     plugin = 0;
+
+    char * old_python_home = getenv("PYTHONHOME");
+    if (old_python_home == NULL)
+    {
+#ifdef PYTHON_DEBUG
+        std::cout << "setting PYTHONHOME" << std::endl;
+#endif
+
+#ifdef _WIN32
+        _putenv_s("PYTHONHOME", "C:\\Users\\Ephys\\Anaconda3"); // set to default PYTHONHOME by PythonEnv.props
+#else
 #define QUOTE(name) #name
 #define STR(macro) QUOTE(macro)
 #define PYTHON_HOME_NAME STR(PYTHON_HOME)
-    char * old_python_home = getenv("PYTHONHOME");
-    if (old_python_home == NULL)
-				{
-#ifdef PYTHON_DEBUG
-					std::cout << "setting PYTHONHOME" << std::endl;
+
+        //setenv("PYTHONHOME", "/anaconda3/bin/", 1); // FIXME hardcoded PYTHONHOME!
+        setenv("PYTHONHOME", PYTHON_HOME_NAME, 1);
+        //setenv("PYTHONHOME", "/anaconda3/bin/python.app", 1); // FIXME hardcoded PYTHONHOME!
 #endif
-            //setenv("PYTHONHOME", "/anaconda3/bin/", 1); // FIXME hardcoded PYTHONHOME!
-        	setenv("PYTHONHOME", PYTHON_HOME_NAME, 1);
-            //setenv("PYTHONHOME", "/anaconda3/bin/python.app", 1); // FIXME hardcoded PYTHONHOME!
-                }
+    }
     // setenv("PYTHONHOME", "/usr/local/anaconda", 1); // FIXME hardcoded PYTHONHOME!
- 
+
 #ifdef PYTHON_DEBUG
     std::cout << "PYTHONHOME: " << getenv("PYTHONHOME") << std::endl;
 #endif
@@ -88,13 +98,14 @@ PythonPlugin::PythonPlugin(const String &processorName)
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
 #endif
     std::cout << "in constructor pthread_threadid_np()=" << tid << std::endl;
 #endif
-    
 
 #if PY_MAJOR_VERSION==3
     Py_SetProgramName ((wchar_t *)"PythonPlugin");
@@ -118,9 +129,13 @@ PythonPlugin::PythonPlugin(const String &processorName)
 
 PythonPlugin::~PythonPlugin()
 {
-    // Problem when removing plugin from signal chain
-    //Py_Finalize();
+#ifdef _WIN32
+	//Close libary
+	PyGILState_Ensure();
+	FreeLibrary((HMODULE)plugin);
+#else
 	dlclose(plugin);
+#endif
 }
 
 void PythonPlugin::createEventChannels()
@@ -157,13 +172,14 @@ bool PythonPlugin::isReady()
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
 #endif
     std::cout << "in isReady pthread_threadid_np()=" << tid << std::endl;
 #endif
-
 
     bool ret;
     PyEval_RestoreThread(GUIThreadState);
@@ -202,11 +218,12 @@ void PythonPlugin::setParameter(int parameterIndex, float newValue)
 
 void PythonPlugin::resetConnections()
 {
-    
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
@@ -217,6 +234,7 @@ void PythonPlugin::resetConnections()
     nextAvailableChannel = 0;
     
     wasConnected = false;
+
 #ifdef PYTHON_DEBUG
     std::cout << "resetting ThreadState, which was "  << processThreadState << std::endl;
 #endif
@@ -226,10 +244,13 @@ void PythonPlugin::resetConnections()
 void PythonPlugin::process(AudioSampleBuffer& buffer)
 {
     checkForEvents(true);
+
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
@@ -473,6 +494,8 @@ void PythonPlugin::sendEventPlugin(int eventType, int sourceID, int subProcessor
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
@@ -511,13 +534,14 @@ void PythonPlugin::handleSpike(const SpikeChannel* spikeInfo, const MidiMessage&
     }
     //juce::uint16
     int sortedID = int(newSpike->getSortedID());
-    const SpikeChannel* chan = newSpike->getChannelInfo();
-    int electrode = chan->getSourceIndex();
     
+
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
@@ -578,7 +602,7 @@ void PythonPlugin::handleSpike(const SpikeChannel* spikeInfo, const MidiMessage&
     //    gstate = PyGILState_Ensure();
     //    std::cout << "in process, lock acquired" << std::endl;
     
-    (*spikeFunction)(electrode, sortedID, spikeBuf);
+    (*spikeFunction)(sortedID, spikeBuf);
     processThreadState = PyEval_SaveThread();
 
     //PyGILState_Release(gstate);
@@ -613,12 +637,34 @@ void PythonPlugin::handleSpike(const SpikeChannel* spikeInfo, const MidiMessage&
  void set FloatParameter(char *name, float value) set float parameter
  
  */
+
+std::string GetLastErrorAsString()
+{
+    /*Get the error message, if any.*/
+    DWORD errorMessageID = ::GetLastError();
+    if(errorMessageID == 0)
+        return std::string(); //No error message has been recorded
+
+    LPSTR messageBuffer = nullptr;
+    size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+    std::string message(messageBuffer, size);
+
+    //Free the buffer.
+    LocalFree(messageBuffer);
+
+    return message;
+}
+
 void PythonPlugin::setFile(String fullpath)
 {
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
     tid = syscall(SYS_gettid);
+#elif defined(_WIN32)
+    DWORD tid = GetCurrentThreadId();
 #else
     uint64_t tid;
     pthread_threadid_np(NULL, &tid);
@@ -626,21 +672,36 @@ void PythonPlugin::setFile(String fullpath)
     std::cout << "in setFile pthread_threadid_np()=" << tid << std::endl;
 #endif
     
-
+#ifdef _WIN32
+	//Load plugin
     filePath = fullpath;
+	std::string path = filePath.toStdString();
+    plugin = LoadLibraryA(path.c_str());
+#else
+	filePath = fullpath;
 
-    const char* path = filePath.getCharPointer();
-    plugin = dlopen(path, RTLD_LAZY);
+	const char* path = filePath.getCharPointer();
+	plugin = dlopen(path, RTLD_LAZY);
+#endif
     if (!plugin)
       {
-          std::cout << "Can't open plugin "
-                    << '"' << path << "\""
-                    << dlerror()
-                    << std::endl;
-          return;
+#ifdef _WIN32
+		  std::cout << "Can't open plugin "
+			  << '"' << path << "\"" 
+			  << std::endl << GetLastErrorAsString() << std::endl;
+		  return;
+#else
+		  std::cout << "Can't open plugin "
+			  << '"' << path << "\""
+			  << dlerror()
+			  << std::endl;
+		  return;
+#endif
       }
 
-    String initPlugin = filePath.fromLastOccurrenceOf(String("/"), false, true);
+    //String initPlugin = filePath.fromLastOccurrenceOf(String("/"), false, true);
+    //Path is dif in windows..
+    String initPlugin = filePath.fromLastOccurrenceOf(String("\\"), false, true);
     
     initPlugin = initPlugin.upToFirstOccurrenceOf(String("."), false, true);
     
@@ -653,168 +714,302 @@ void PythonPlugin::setFile(String fullpath)
     
     std::cout << "init function is: " << initPluginName << std::endl;
     
-    void *initializer = dlsym(plugin,initPluginName.getCharPointer());
+    void *initializer;
     
+#ifdef _WIN32
+	initializer = GetProcAddress((HMODULE)plugin, initPluginName.getCharPointer());
+#else
+	initializer = dlsym(plugin, initPluginName.getCharPointer());
+#endif
+
 #ifdef PYTHON_DEBUG
-    std::cout << "initializer: " << initializer << std::endl;
+	std::cout << "initializer: " << initializer << std::endl;
 #endif
     if (!initializer)
     {
-    	std::cout << "Can't find init function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-    	plugin = 0;
-    	return;
+#ifdef _WIN32
+        std::cout << "Can't find init function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+        plugin = 0;
+        return;
+#else
+        std::cout << "Can't find init function in plugin "
+            << '"' << path << "\"" << std::endl
+            << dlerror()
+            << std::endl;
+        plugin = 0;
+        return;
+#endif
     }
-    
+
     initfunc_t initF = (initfunc_t) initializer;
-    
-    void *cfunc = dlsym(plugin,"pluginisready");
+	void *cfunc;
+#ifdef _WIN32
+    cfunc = GetProcAddress((HMODULE)plugin, "pluginisready");
+#else
+	cfunc = dlsym(plugin, "pluginisready");
+#endif
     if (!cfunc)
     {
-    	std::cout << "Can't find ready function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-    	plugin = 0;
-    	return;
+#ifdef _WIN32
+		std::cout << "Can't find ready function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find ready function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     pluginIsReady = (isreadyfunc_t)cfunc;
 
-    cfunc = dlsym(plugin,"pluginStartup");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "pluginStartup");
+#else
+	cfunc = dlsym(plugin, "pluginStartup");
+#endif
     if (!cfunc)
     {
-    	std::cout << "Can't find startup function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        plugin = 0;
-        return;
+#ifdef _WIN32
+		std::cout << "Can't find startup function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find startup function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     pluginStartupFunction = (startupfunc_t)cfunc;
     
-    cfunc = dlsym(plugin,"getParamNum");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "getParamNum");
+#else
+	cfunc = dlsym(plugin, "getParamNum");
+#endif
+
     if (!cfunc)
     {
-    	std::cout << "Can't find getParamNum function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        plugin = 0;
-        return;
+#ifdef _WIN32
+		std::cout << "Can't find getParamNum function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find getParamNum function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     getParamNumFunction = (getparamnumfunc_t)cfunc;
     
 
-    cfunc = dlsym(plugin,"getParamConfig");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "getParamConfig");
+#else
+	cfunc = dlsym(plugin, "getParamConfig");
+#endif
     if (!cfunc)
     {
-    	std::cout << "Can't find getParamNum function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        //    	plugin = 0;
-        //    	return;
+#ifdef _WIN32
+		std::cout << "Can't find getParamNum function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		   	plugin = 0; 
+		   	return;
+#else
+		std::cout << "Can't find getParamNum function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		//   	plugin = 0;
+		//   	return;
+#endif
     }
     getParamConfigFunction = (getparamconfigfunc_t)cfunc;
 
     
-    cfunc = dlsym(plugin,"pluginFunction");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "pluginFunction");
+#else
+	cfunc = dlsym(plugin, "pluginFunction");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-    	std::cout << "Can't find plugin function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-    	plugin = 0;
-    	return;
+#ifdef _WIN32
+		std::cout << "Can't find plugin function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find plugin function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     pluginFunction = (pluginfunc_t)cfunc;
     
     // CJB added start
-    
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "eventFunction");
+#else
     cfunc = dlsym(plugin,"eventFunction");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-        std::cout << "Can't find plugin function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        plugin = 0;
-        return;
+#ifdef _WIN32
+		std::cout << "Can't find plugin function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find plugin function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
+
     }
     eventFunction = (eventfunc_t)cfunc;
     
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "spikeFunction");
+#else
     cfunc = dlsym(plugin,"spikeFunction");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-        std::cout << "Can't find plugin function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        plugin = 0;
-        return;
+#ifdef _WIN32
+		std::cout << "Can't find plugin function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find plugin function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     spikeFunction = (spikefunc_t)cfunc;
     
     // CJB added end
 
-    cfunc = dlsym(plugin,"setIntParam");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "setIntParam");
+#else
+	cfunc = dlsym(plugin, "setIntParam");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
+#ifdef _WIN32
+		std::cout << "Can't find setIntParam function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
     	std::cout << "Can't find setIntParam function in plugin "
         << '"' << path << "\"" << std::endl
         << dlerror()
         << std::endl;
     	plugin = 0;
     	return;
+#endif
     }
     setIntParamFunction = (setintparamfunc_t)cfunc;
     
-    cfunc = dlsym(plugin,"setFloatParam");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "setFloatParam");
+#else
+	cfunc = dlsym(plugin, "setFloatParam");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-    	std::cout << "Can't find setFloatParam function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-    	plugin = 0;
-    	return;
+#ifdef _WIN32
+		std::cout << "Can't find setFloatParam function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find setFloatParam function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
 
     setFloatParamFunction = (setfloatparamfunc_t)cfunc;
 
-    cfunc = dlsym(plugin, "getIntParam");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "getIntParam");
+#else
+	cfunc = dlsym(plugin, "getIntParam");
+#endif
+
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
+#ifdef _WIN32
+		std::cout << "Can't find getIntParam function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
         std::cout << "Can't find getIntParam function in plugin "
         << '"' << path << "\"" << std::endl
         << dlerror()
         << std::endl;
         plugin = 0;
         return;
+#endif
     }
     getIntParamFunction = (getintparamfunc_t)cfunc;
     
-
-    
-    cfunc = dlsym(plugin, "getFloatParam");
+#ifdef _WIN32
+	cfunc = GetProcAddress((HMODULE)plugin, "getFloatParam");
+#else
+	cfunc = dlsym(plugin, "getFloatParam");
+#endif
     // std::cout << "plugin:   " << cfunc << std::endl;
     if (!cfunc)
     {
-        std::cout << "Can't find getFloatParam function in plugin "
-        << '"' << path << "\"" << std::endl
-        << dlerror()
-        << std::endl;
-        plugin = 0;
-        return;
+#ifdef _WIN32
+		std::cout << "Can't find getFloatParam function in plugin "
+            << '"' << path << "\"" << std::endl << GetLastErrorAsString() << std::endl;
+		plugin = 0;
+		return;
+#else
+		std::cout << "Can't find getFloatParam function in plugin "
+			<< '"' << path << "\"" << std::endl
+			<< dlerror()
+			<< std::endl;
+		plugin = 0;
+		return;
+#endif
     }
     
     getFloatParamFunction = (getfloatparamfunc_t)cfunc;
@@ -887,6 +1082,8 @@ void PythonPlugin::updateSettings()
 void PythonPlugin::setIntPythonParameter(String name, int value)
 {
     
+#ifdef _WIN32
+#else
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
@@ -897,6 +1094,7 @@ void PythonPlugin::setIntPythonParameter(String name, int value)
 #endif
     std::cout << "in setintparam pthread_threadid_np()=" << tid << std::endl;
 #endif
+#endif
     
     PyEval_RestoreThread(GUIThreadState);
     (*setIntParamFunction)(name.getCharPointer().getAddress(), value);
@@ -906,6 +1104,8 @@ void PythonPlugin::setIntPythonParameter(String name, int value)
 void PythonPlugin::setFloatPythonParameter(String name, float value)
 {
 
+#ifdef _WIN32
+#else
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
@@ -916,6 +1116,7 @@ void PythonPlugin::setFloatPythonParameter(String name, float value)
 #endif
     std::cout << "in setfloatparam pthread_threadid_np()=" << tid << std::endl;
 #endif
+#endif
     PyEval_RestoreThread(GUIThreadState);
     (*setFloatParamFunction)(name.getCharPointer().getAddress(), value);
     GUIThreadState = PyEval_SaveThread();
@@ -923,7 +1124,8 @@ void PythonPlugin::setFloatPythonParameter(String name, float value)
 
 int PythonPlugin::getIntPythonParameter(String name)
 {
-
+#ifdef _WIN32
+#else
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
@@ -933,6 +1135,7 @@ int PythonPlugin::getIntPythonParameter(String name)
     pthread_threadid_np(NULL, &tid);
 #endif
     std::cout << "in getintparam pthread_threadid_np()=" << tid << std::endl;
+#endif
 #endif
 
     int value;
@@ -945,7 +1148,8 @@ int PythonPlugin::getIntPythonParameter(String name)
 float PythonPlugin::getFloatPythonParameter(String name)
 {
     
-    
+#ifdef _WIN32
+#else
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
     pid_t tid;
@@ -955,6 +1159,7 @@ float PythonPlugin::getFloatPythonParameter(String name)
     pthread_threadid_np(NULL, &tid);
 #endif
     std::cout << "in getfloatparam pthread_threadid_np()=" << tid << std::endl;
+#endif
 #endif
     
     PyEval_RestoreThread(GUIThreadState);

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -39,7 +39,17 @@
 #ifndef __PYTHONPLUGIN_H
 #define __PYTHONPLUGIN_H
 
+//Hack to get around python37_d.lib not exisiting on Windows (at least on my system)
+#if defined(_WIN32) && defined(_DEBUG)
+#define _DEBUG_TEMP _DEBUG
+#undef _DEBUG
 #include <Python.h>
+#define _DEBUG _DEBUG_TEMP
+#undef _DEBUG_TEMP
+#else
+#include <Python.h>
+#endif
+
 
 #if PY_MAJOR_VERSION>=3
 #define DL_IMPORT PyAPI_FUNC
@@ -69,7 +79,7 @@ typedef PyObject * (*initfunc_t)(void);
 //#endif
 typedef DL_IMPORT(void) (*startupfunc_t)(float); // passes the sampling rate
 typedef DL_IMPORT(void) (*eventfunc_t)(int, int, int, double, int);// CJB added
-typedef DL_IMPORT(void) (*spikefunc_t)(int, int, float[18]);// CJB added
+typedef DL_IMPORT(void) (*spikefunc_t)(int, float[18]);// CJB added
 typedef DL_IMPORT(void) (*pluginfunc_t)(float *, int, int, int, PythonEvent *);
 typedef DL_IMPORT(int) (*isreadyfunc_t)(void);
 typedef DL_IMPORT(int) (*getparamnumfunc_t)(void);
@@ -202,7 +212,11 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
     bool wasTriggered = 0;
     uint16 lastChan = 0;
-
+	//Windows Port Variables
+#ifdef _WIN32
+	HINSTANCE old_python_home;
+	PyThreadState *mainstate = NULL;
+#endif
 };
 
 

--- a/WindowsPlugin/Python.vcxproj
+++ b/WindowsPlugin/Python.vcxproj
@@ -1,0 +1,172 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{03F9F201-3F09-48C1-B4EC-73C5904632F6}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Python</RootNamespace>
+    <ProjectName>PythonPlugin</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Debug32.props" />
+    <Import Project="PythonEnv.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Debug64.props" />
+    <Import Project="PythonEnv.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Release32.props" />
+    <Import Project="PythonEnv.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Release64.props" />
+    <Import Project="PythonEnv.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\OpenEphysLib.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEditor.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonFilter.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonPlugin.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSink.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSource.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEditor.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEvent.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonFilter.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonParamConfig.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonPlugin.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSink.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSource.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/WindowsPlugin/Python.vcxproj.filters
+++ b/WindowsPlugin/Python.vcxproj.filters
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEditor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonFilter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonPlugin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSink.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSource.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\PythonPlugin\OpenEphysLib.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEditor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonEvent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonFilter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonParamConfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonPlugin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSink.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\PythonPlugin\PythonSource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/WindowsPlugin/PythonEnv.props
+++ b/WindowsPlugin/PythonEnv.props
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <PYTHONHOME_DEFAULT>$(USERPROFILE)\Anaconda3</PYTHONHOME_DEFAULT>
+    <PYTHONHOME Condition="'$(PYTHONHOME)' == ''">$(PYTHONHOME_DEFAULT)</PYTHONHOME>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(PYTHONHOME)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PYTHONHOME_DEFAULT=R"?($(PYTHONHOME_DEFAULT))?";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(PYTHONHOME)\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>python36.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy /Y "$(PYTHONHOME)\python37.dll" "$(GUIDir)"
+%(Command)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="PYTHONHOME">
+      <Value>$(PYTHONHOME)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Here are my changes to get the PythonPlugin working in windows. Couple things to note.

Implementation was simple, I included an `#ifdef _WIN32` around all linux functions.
`dlopen()` is analogous to `LoadLibrary()`
`dlsym()` -> `GetProcAddress()`
`dlclose()` -> `FreeLibrary()`

A PythonEnv.props file was made for the visual studio project to add python36 to the path. This along with the proj file can be found in the WindowsPlugin folder.

All is good there.

However, our big issue is the difference between how cython behaves in linux vs windows. Cython in linux creates a .so file that has all functions visible. Windows on the other hand creates a .pyd file that has all, except PyInit_modulename() as hidden which means `GetProcAddress()` can't get all of the functions. I've posted to the cython-users google group and stackoverflow and haven't heard anything from anyone yet on creating visible functions. 

Hopefully there is a work around, otherwise Windows may need a rebuild using builtin python functions.


