### PR TITLE
Make generatePlugin.py cross-platform

### DIFF
--- a/python_modules/generatePlugin.py
+++ b/python_modules/generatePlugin.py
@@ -1,17 +1,16 @@
 import sys
-from subprocess import call
-call(["mkdir",str(sys.argv[1])])
-w = open(str(sys.argv[1])+'/'+'setup.py','w+')
-with open('template/setup.py','r') as f:
-	for line in f:
-		toWrite = line.replace("EXAMPLE",str(sys.argv[1]))
-		w.write(toWrite)
-w.close()
-f.close()
-w = open(str(sys.argv[1])+'/'+str(sys.argv[1])+'.pyx','w+')
-with open('template/template.pyx','r') as f:
-	for line in f:
-		toWrite = line.replace("EXAMPLE",str(sys.argv[1]))
-		w.write(toWrite)
-w.close()
-f.close()
+import os
+name = str(sys.argv[1])
+os.mkdir(name)
+
+with open(os.path.join(name, 'setup.py'),'w+') as w:
+	with open('template/setup.py','r') as f:
+		for line in f:
+			toWrite = line.replace("EXAMPLE", name)
+			w.write(toWrite)
+
+with open(os.path.join(name, name +'.pyx'),'w+') as w:
+	with open('template/template.pyx','r') as f:
+		for line in f:
+			toWrite = line.replace("EXAMPLE", name)
+			w.write(toWrite)


### PR DESCRIPTION
Allows the `generatePlugin.py` script to be used on platforms without "mkdir" (e.g. Windows).