### PR TITLE
Reduce crashing when using multiple Python Plugin instances

### DIFF
--- a/PythonPlugin/PythonPlugin.cpp
+++ b/PythonPlugin/PythonPlugin.cpp
@@ -59,16 +59,8 @@ v
 #endif
 #endif
 
-
-PythonPlugin::PythonPlugin(const String &processorName)
-    : GenericProcessor(processorName) //, threshold(200.0), state(true)
-
+static PyThreadState* startInterpreter()
 {
-
-    //parameters.add(Parameter("thresh", 0.0, 500.0, 200.0, 0));
-    filePath = "";
-    plugin = 0;
-
     // if on windows, PYTHON_HOME_NAME is set by PythonEnv.props (corresponds to CONDA_HOME environment variable)
 #ifndef _WIN32
 #define QUOTE(name) #name
@@ -98,6 +90,33 @@ PythonPlugin::PythonPlugin(const String &processorName)
     // set PYTHONPATH to avoid error described here: https://stackoverflow.com/questions/5694706/py-initialize-fails-unable-to-load-the-file-system-codec
     _putenv_s("PYTHONPATH", PYTHON_HOME_NAME "\\DLLs;" PYTHON_HOME_NAME "\\Lib;" PYTHON_HOME_NAME "\\Lib\\site-packages");
 #endif
+
+#if PY_MAJOR_VERSION==3
+    Py_SetProgramName((wchar_t *)"PythonPlugin");
+#else
+    Py_SetProgramName((char *)"PythonPlugin");
+#endif
+    Py_Initialize();
+    PyEval_InitThreads();
+
+    PyRun_SimpleString("import sys");
+    PyRun_SimpleString("sys.setcheckinterval(10000)");
+#ifdef PYTHON_DEBUG
+    std::cout << Py_GetPrefix() << std::endl;
+    std::cout << Py_GetVersion() << std::endl;
+#endif
+    return PyEval_SaveThread();
+}
+
+
+PythonPlugin::PythonPlugin(const String &processorName)
+    : GenericProcessor(processorName) //, threshold(200.0), state(true)
+
+{
+
+    //parameters.add(Parameter("thresh", 0.0, 500.0, 200.0, 0));
+    filePath = "";
+    plugin = 0;
     
 #ifdef PYTHON_DEBUG
 #if defined(__linux__)
@@ -112,34 +131,30 @@ PythonPlugin::PythonPlugin(const String &processorName)
     std::cout << "in constructor pthread_threadid_np()=" << tid << std::endl;
 #endif
 
-#if PY_MAJOR_VERSION==3
-    Py_SetProgramName ((wchar_t *)"PythonPlugin");
-#else
-    Py_SetProgramName ((char *)"PythonPlugin");
-#endif
-    Py_Initialize ();
-    PyEval_InitThreads();
-
-    
-    PyRun_SimpleString("import sys");
-    PyRun_SimpleString("sys.setcheckinterval(10000)");
-#ifdef PYTHON_DEBUG
-    std::cout << Py_GetPrefix() << std::endl;
-    std::cout << Py_GetVersion() << std::endl;
-#endif
-    GUIThreadState = PyEval_SaveThread();
+    if (Py_IsInitialized())
+    {
+        // have a thread state already, just need to retrieve it
+        GUIThreadState = PyGILState_GetThisThreadState();
+    }
+    else
+    {
+        GUIThreadState = startInterpreter();
+    }
 }
 
 PythonPlugin::~PythonPlugin()
 {
+    if (plugin)
+    {
 #ifdef _WIN32
-    //Close libary
-    PyGILState_Ensure();
-    FreeLibrary((HMODULE)plugin);
+        //Close libary
+        FreeLibrary((HMODULE)plugin);
 #else
-    dlclose(plugin);
+        dlclose(plugin);
 #endif
+    }
 }
+
 
 void PythonPlugin::createEventChannels()
 {
@@ -998,7 +1013,7 @@ void PythonPlugin::setFile(String fullpath)
     std::cout << "after initplugin" << std::endl; // DEBUG
 #endif
 
-    (*pluginStartupFunction)(dataSampleRate);
+    (*pluginStartupFunction)(getSampleRate());
     
     // load the parameter configuration
     numPythonParams = (*getParamNumFunction)();
@@ -1045,14 +1060,7 @@ String PythonPlugin::getFile()
 
 void PythonPlugin::updateSettings()
 {
-    // update the sample rate...
-    // if you have input data channels, we'll use the first one's sample rate (sane?)
-    // otherwise, we'll just use the superclass' implementation if getSampleRate()
-    if (getNumInputs() > 0) {
-        dataSampleRate = getDataChannel(0)->getSampleRate();
-    } else {
-        dataSampleRate = GenericProcessor::getSampleRate();
-    }
+
 }
 
 void PythonPlugin::setIntPythonParameter(String name, int value)

--- a/PythonPlugin/PythonPlugin.cpp
+++ b/PythonPlugin/PythonPlugin.cpp
@@ -347,12 +347,6 @@ void PythonPlugin::process(AudioSampleBuffer& buffer)
 #endif
 }
 
-bool PythonPlugin::disable()
-{
-    updateProcessThreadState = true;
-    return true;
-}
-
 /** START CJB ADDED **/
 
 void PythonPlugin::handleEvent(const EventChannel* eventInfo, const MidiMessage& event, int sampleNum){

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -101,37 +101,7 @@ typedef DL_IMPORT(float) (*getfloatparamfunc_t)(char*);
 //=============================================================================
 /*
 */
-
-
-class PythonCallerWithThread
-{
-public:
-    PythonCallerWithThread() = default;
-
-protected:
-    class PythonLock
-    {
-    public:
-        PythonLock();
-        ~PythonLock();
-
-    private:
-        const PyGILState_STATE pgss;
-
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonLock);
-    };
-
-private:
-    static PyThreadState* startInterpreter();
-
-    static const PyThreadState* mainState;
-    static PyThreadState* threadState;
-
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonCallerWithThread);
-};
-
-
-class PythonPlugin : public GenericProcessor, public PythonCallerWithThread
+class PythonPlugin : public GenericProcessor
 {
 public:
     /** The class constructor, used to initialize any members. */
@@ -209,16 +179,37 @@ public:
         
     void saveCustomParametersToXml (XmlElement* parentElement) override;
     void loadCustomParametersFromXml() override;
+
 private:
     void sendEventPlugin(int eventType, int sourceID, int subProcessorIdx, double timestamp, int sourceIndex); //CJB added
+
+    /* Added by EBB
+     Why do it this way:
+     * Using a class allows object destruction to control releasing the GIL (RAII)
+     * Private inner class so that random other objects with other threads can't use it;
+       it's just for the main GUI and process threads
+     * Static state pointers b/c all instances of PythonPlugin use the same threads and therefore
+       can use the same Python states
+     * State pointers encapuslated in here so that they can only be manipulated by creating
+       and destroying PythonLocks (abstracting away confusing Python C API)
+     */
+    class PythonLock
+    {
+    public:
+        PythonLock();
+        ~PythonLock();
+
+    private:
+        const PyGILState_STATE pgss;
+
+        static const PyThreadState* mainState;
+        static PyThreadState* threadState;
+
+        JUCE_DECLARE_NON_COPYABLE(PythonLock);
+    };
+
     String filePath;
     void *plugin;
-    // private members and methods go here
-    //
-    // e.g.:
-    //
-    // float threshold;
-    // bool state;
     int numPythonParams = 0;
     ParamConfig *params;
     Component **paramsControl;
@@ -237,14 +228,10 @@ private:
     eventfunc_t eventFunction;
     spikefunc_t spikeFunction;
     const EventChannel* ttlChannel{ nullptr };
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
     bool wasTriggered = 0;
     uint16 lastChan = 0;
-	//Windows Port Variables
-#ifdef _WIN32
-	HINSTANCE old_python_home;
-	PyThreadState *mainstate = NULL;
-#endif
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
 };
 
 

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -180,8 +180,6 @@ public:
          */
     virtual void process(AudioSampleBuffer& buffer /* , MidiBuffer& events */);
 
-    bool disable() override;
-    
     void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int sampleNum); // CJB added
     void handleSpike(const SpikeChannel* channelInfo, const MidiMessage& event, int samplePosition); //CJB added
     
@@ -252,7 +250,6 @@ private:
     getfloatparamfunc_t getFloatParamFunction;
     eventfunc_t eventFunction;
     spikefunc_t spikeFunction;
-    bool updateProcessThreadState = true;
     const EventChannel* ttlChannel{ nullptr };
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
     bool wasTriggered = 0;

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -101,6 +101,22 @@ typedef DL_IMPORT(float) (*getfloatparamfunc_t)(char*);
 //=============================================================================
 /*
 */
+
+class ManualPyThreadState
+{
+public:
+    explicit ManualPyThreadState(PyThreadState* creatorState);
+    ~ManualPyThreadState();
+    operator PyThreadState*();
+    ManualPyThreadState& operator=(PyThreadState* otherState);
+
+private:
+    PyThreadState* creator;
+    PyThreadState* state;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ManualPyThreadState)
+};
+
 class PythonPlugin    : public GenericProcessor
 {
 public:
@@ -176,9 +192,7 @@ public:
     
     int getIntPythonParameter(String name);
     float getFloatPythonParameter(String name);
-    
-    void resetConnections();
-    
+        
     void saveCustomParametersToXml (XmlElement* parentElement) override;
     void loadCustomParametersFromXml() override;
 private:
@@ -208,8 +222,8 @@ private:
     getfloatparamfunc_t getFloatParamFunction;
     eventfunc_t eventFunction;
     spikefunc_t spikeFunction;
-    PyThreadState *GUIThreadState = 0;
-    PyThreadState *processThreadState = 0;
+    static PyThreadState *GUIThreadState;
+    static ManualPyThreadState processThreadState;
     const EventChannel* ttlChannel{ nullptr };
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
     bool wasTriggered = 0;

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -105,12 +105,18 @@ typedef DL_IMPORT(float) (*getfloatparamfunc_t)(char*);
 class ManualPyThreadState
 {
 public:
+    // initializes with a null state.
     explicit ManualPyThreadState(PyThreadState* creatorState);
     ~ManualPyThreadState();
+
+    void updateIfThreadChanged();
+
     operator PyThreadState*();
     ManualPyThreadState& operator=(PyThreadState* otherState);
 
 private:
+    static void deleteThreadState(PyThreadState*& deleter, PyThreadState* deleted);
+
     PyThreadState* creator;
     PyThreadState* state;
 
@@ -151,6 +157,8 @@ public:
         size of the buffer).
          */
     virtual void process(AudioSampleBuffer& buffer /* , MidiBuffer& events */);
+
+    bool disable() override;
     
     void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int sampleNum); // CJB added
     void handleSpike(const SpikeChannel* channelInfo, const MidiMessage& event, int samplePosition); //CJB added
@@ -224,6 +232,7 @@ private:
     spikefunc_t spikeFunction;
     static PyThreadState *GUIThreadState;
     static ManualPyThreadState processThreadState;
+    bool updateProcessThreadState = true;
     const EventChannel* ttlChannel{ nullptr };
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonPlugin);
     bool wasTriggered = 0;

--- a/PythonPlugin/PythonPlugin.h
+++ b/PythonPlugin/PythonPlugin.h
@@ -122,24 +122,10 @@ protected:
     };
 
 private:
-    class ManualPyThreadState
-    {
-    public:
-        explicit ManualPyThreadState(PyThreadState* currentState);
-        ~ManualPyThreadState();
-
-        const PyThreadState* rawState() const;
-
-    private:
-        PyThreadState* state;
-
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ManualPyThreadState)
-    };
-
     static PyThreadState* startInterpreter();
 
     static const PyThreadState* mainState;
-    static ScopedPointer<ManualPyThreadState> threadState;
+    static PyThreadState* threadState;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PythonCallerWithThread);
 };

--- a/python_modules/plugin.pyx
+++ b/python_modules/plugin.pyx
@@ -38,7 +38,7 @@ cdef extern from "../../PythonPlugin/PythonEvent.h":
 
 
 # noinspection PyPep8Naming
-cdef public void pluginStartup(float sampling_rate) with gil:
+cdef public void pluginStartup(float sampling_rate):
     print("pre anything")
     global isDebug
     print("after is debug")
@@ -46,11 +46,11 @@ cdef public void pluginStartup(float sampling_rate) with gil:
     pluginOp.startup(sampling_rate)
 
 # noinspection PyPep8Naming
-cdef public int getParamNum()  with gil:
+cdef public int getParamNum():
     return len(pluginOp.param_config())
 
 # noinspection PyPep8Naming
-cdef public void getParamConfig(ParamConfig *params) with gil:
+cdef public void getParamConfig(ParamConfig *params):
     cdef int *ent
     cdef char * par_name
     cdef size_t par_len
@@ -92,7 +92,7 @@ cdef public void getParamConfig(ParamConfig *params) with gil:
 
 
 # noinspection PyPep8Naming
-cdef public void pluginFunction(float *data_buffer, int nChans, int nSamples, int nRealSamples, PythonEvent *events) with gil:
+cdef public void pluginFunction(float *data_buffer, int nChans, int nSamples, int nRealSamples, PythonEvent *events):
     global sr
     n_arr = np.asarray(<np.float32_t[:nChans, :nSamples]> data_buffer)
     #pluginOp.set_events(events)
@@ -129,15 +129,15 @@ cdef public void pluginFunction(float *data_buffer, int nChans, int nSamples, in
         last_e_c.nextEvent = NULL
 
 # noinspection PyPep8Naming
-cdef public void eventFunction(int eventType, int sourceID, int subProcessorIdx, double timestamp, int sourceIndex) with gil:
+cdef public void eventFunction(int eventType, int sourceID, int subProcessorIdx, double timestamp, int sourceIndex):
     pluginOp.handleEvents(eventType,sourceID,subProcessorIdx,timestamp,sourceIndex)
 
 # noinspection PyPep8Naming
-cdef public void spikeFunction(int electrode, int sortedID, float[18] spikeSample) with gil:
+cdef public void spikeFunction(int electrode, int sortedID, float[18] spikeSample):
     n_arr = np.asarray(<np.float32_t[:1, :18]> spikeSample)
     pluginOp.handleSpike(electrode,sortedID,n_arr)
 
-cdef void add_event(PythonEvent *e_c, object e_py) with gil:
+cdef void add_event(PythonEvent *e_c, object e_py):
     e_c.type = <unsigned char>e_py['type']
     e_c.sampleNum = <int>e_py['sampleNum']
     if 'eventId' in e_py:
@@ -151,29 +151,29 @@ cdef void add_event(PythonEvent *e_c, object e_py) with gil:
         # TODO to be tested if this works with a numpy input
 
 
-cdef public int pluginisready() with gil:
+cdef public int pluginisready():
     return pluginOp.is_ready()
 
 # noinspection PyPep8Naming
-cdef public void setIntParam(char *name, int value) with gil:
+cdef public void setIntParam(char *name, int value):
     if isDebug:
         print("In Python: ", name, ": ", value)
     setattr(pluginOp, name.decode('utf-8'), value)
 
 # noinspection PyPep8Naming
-cdef public void setFloatParam(char *name, float value) with gil:
+cdef public void setFloatParam(char *name, float value):
     # print ("In Python: ", name, ": ", value)
     setattr(pluginOp, name.decode('utf-8'), value)
 
 # noinspection PyPep8Naming
-cdef public int getIntParam(char *name) with gil:
+cdef public int getIntParam(char *name):
     if isDebug:
         print("In Python getIntParam: ", name)
     value = getattr(pluginOp, name.decode('utf-8'))
     return <int>value
 
 # noinspection PyPep8Naming
-cdef public float getFloatParam(char *name) with gil:
+cdef public float getFloatParam(char *name):
     # print( "In Python: ", name, ": ", value)
     value =  getattr(pluginOp, name.decode('utf-8'))
     return <float>value


### PR DESCRIPTION
This prevents the situation that was causing the GUI to crash when trying to use two Python plugins in one signal chain, or when creating a new one after deleting one. What was happening was the second plugin was trying to call `Py_Initialize` and do other initialization things in the constructor after Python and the GIL had already been initialized, without acquiring the GIL.

This solution makes the GUI and process thread states static, i.e. global across all Python Plugin instances. They (and Python) are initialized when the GUI starts, and are not destroyed until program termination.

The process thread state poses a challenge, since it can't be created and destroyed within the process thread itself without doing so every time `process` is called, which is probably too costly. `GenericProcessor` does not expose methods called before and after acquisition from the processing thread. Thus, we had the "ugly hack" of creating a thread state manually if needed on the first `process` call, and then not explicitly deleting it. Still, it's suboptimal to have the allocation happening within `process`, even if just once.

To address this, I changed it so that the process thread state gets both created and destroyed from the GUI thread, which is managed by the `ManualPyThreadState` class. This allows it to be shared more easily among instances and properly freed when the program exits. However, it goes against what the `PyGILState_*` family of functions expect, which is that each thread state gets created and destroyed in the thread it is used in.

We don't have to use the `PyGILState` calls at all in our code, but they are also automatically generated in the extensions for each function declared with `with gil:` (which was all of them). However, it's totally unnecessary to use `with gil:` if we're managing the GIL manually from the C++ side. Thus I removed all the `with gil:`s from `plugin.pyx`. _Since the generated `PyGILState_Ensure` calls would otherwise try to acquire the GIL for a new state while it's being held on the C++ side, using a plugin compiled with the old `plugin.pyx` after these changes will result in lots of deadlocks._

There is still a segfault that sometimes pops up (more often in debug builds) when loading a plugin file after the first one since starting the GUI, especially after deleting all Python Plugins and creating a new one. I believe this has to do with `numpy` not wanting to be initialized twice - not in the scope of this PR.
But a release build seems to usually be able to handle adding multiple instances to a signal chain and loading plugins in each of them.

Also fixes a crash when deleting an instance without a plugin loaded on Linux, which was from calling `dlclose` with a null pointer.